### PR TITLE
Updated dependencies from code.google to github.com

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -4,10 +4,10 @@ import (
 	"path"
 	"path/filepath"
 
-	"code.google.com/p/rog-go/exp/go/ast"
-	"code.google.com/p/rog-go/exp/go/parser"
-	"code.google.com/p/rog-go/exp/go/token"
-	"code.google.com/p/rog-go/exp/go/types"
+	"github.com/rogpeppe/godef/go/ast"
+	"github.com/rogpeppe/godef/go/parser"
+	"github.com/rogpeppe/godef/go/token"
+	"github.com/rogpeppe/godef/go/types"
 )
 
 var fileset = types.FileSet

--- a/findReferences.go
+++ b/findReferences.go
@@ -5,8 +5,8 @@ import (
 	"path"
 	"strings"
 
-	"code.google.com/p/rog-go/exp/go/ast"
-	"code.google.com/p/rog-go/exp/go/parser"
+	"github.com/rogpeppe/godef/go/ast"
+	"github.com/rogpeppe/godef/go/parser"
 )
 
 func (def Definition) findReferences(searchpath string, recursive bool) (chan Reference, chan error) {

--- a/lookup.go
+++ b/lookup.go
@@ -3,9 +3,9 @@ package ident
 import (
 	"errors"
 
-	"code.google.com/p/rog-go/exp/go/ast"
-	"code.google.com/p/rog-go/exp/go/parser"
-	"code.google.com/p/rog-go/exp/go/types"
+	"github.com/rogpeppe/godef/go/ast"
+	"github.com/rogpeppe/godef/go/parser"
+	"github.com/rogpeppe/godef/go/types"
 )
 
 func lookup(filepath string, offset int) (Definition, error) {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package ident
 
-import "code.google.com/p/rog-go/exp/go/token"
+import "github.com/rogpeppe/godef/go/token"
 
 // Definition is the code position that defines either a
 // - func


### PR DESCRIPTION
Modified imports to point to github.com instead of code.google for parser, token, types and ast dependencies.